### PR TITLE
typo: missing backslash at end

### DIFF
--- a/people/wolfgang-huber.qmd
+++ b/people/wolfgang-huber.qmd
@@ -31,7 +31,7 @@ He started a research group at [EMBL-EBI (European Bioinformatics Institute)](ht
 
 In 2009, he joined the new Genome Biology unit at EMBL Heidelberg.
 
-With Susan Holmes, he co-wrote the textbook [Modern Statistics for Modern Biology](https://www.huber.embl.de/msmb).
+With Susan Holmes, he co-wrote the textbook [Modern Statistics for Modern Biology](https://www.huber.embl.de/msmb/).
 
 Wolfgang is interested in open source software community building, and engages in courses, workshops and consortia that help drive these. He is also deeply committed to cross-disciplinary scientific training: teaching biologists and medical researchers in statistics, computation and AI, and teaching computational scientists in biological applications and data generating technologies. 
 


### PR DESCRIPTION
**Typo**:
1. Missing backslash at the end of the link [https://www.huber.embl.de/msmb](https://www.huber.embl.de/msmb) output is: <br>
    ![without_backslash](https://github.com/user-attachments/assets/aa89ff00-6ff3-4202-a409-277708eaa880)

2. With backslash [https://www.huber.embl.de/msmb/](https://www.huber.embl.de/msmb/) <br>
![with_backslash](https://github.com/user-attachments/assets/66a1a90d-6a23-4967-a1cf-b04d336474f8)

3. **Note** The same link is found in [research.qmd](https://github.com/Huber-group-EMBL/Huber-group-EMBL.github.io/blob/main/research.qmd), [rbioceulogy.qmd](https://github.com/Huber-group-EMBL/Huber-group-EMBL.github.io/blob/main/rbioceulogy.qmd), [statsthreads.qmd](https://github.com/Huber-group-EMBL/Huber-group-EMBL.github.io/blob/main/statsthreads.qmd) where it is already with backslash and are working fine.
